### PR TITLE
Add metadata/layout.conf

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,0 +1,1 @@
+masters = gentoo


### PR DESCRIPTION
Add metadata layout for overlay, necessary for future overlay support
in portage.

Addresses the following error in newer versions of portage:

```
!!! Repository 'sublime-text' is missing masters attribute in '/usr/overlays/sublime-text/metadata/layout.conf'
!!! Set 'masters = gentoo' in this file for future compatibility
```
