### PR TITLE
Add Sublime license to EULA license group

### DIFF
--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -1,0 +1,1 @@
+EULA Sublime


### PR DESCRIPTION
This adds the file `license_groups`. As result, the user has to accept the license explicitly via an entry in `/etc/portage/package.license`.